### PR TITLE
MK-344: add metadata field to a block request

### DIFF
--- a/types/block_request.go
+++ b/types/block_request.go
@@ -20,4 +20,8 @@ package types
 type BlockRequest struct {
 	NetworkIdentifier *NetworkIdentifier      `json:"network_identifier"`
 	BlockIdentifier   *PartialBlockIdentifier `json:"block_identifier"`
+	// Metadata is a Foundry specific field that allows for clients to request for
+	// specific information within a block. Rosetta implementations should ensure that
+	// any special behavior that happens when metadata is supplied is documented.
+	Metadata map[string]interface{} `json:"metadata"`
 }


### PR DESCRIPTION
Adding a metadata field to a `BlockRequest` for Rosetta clients to be able to request specific information from the block endpoint. Rosetta ETH2 will accept a list of addresses in the metadata so that it can filter down the addresses that it includes in the block's operations to put less pressure on the node.