### PR TITLE
add account balance metadata to request

### DIFF
--- a/types/account_balance_request.go
+++ b/types/account_balance_request.go
@@ -27,4 +27,9 @@ type AccountBalanceRequest struct {
 	// AccountIdentifier. If the currencies field is populated, only balances for the specified
 	// currencies will be returned. If not populated, all available balances will be returned.
 	Currencies []*Currency `json:"currencies,omitempty"`
+	// Metadata is a Foundry specific field that allows for the account balance endpoint
+	// to access the balances of the accounts that have delegated to our validator
+	//Rosetta implementations should ensure that
+	// any special behavior that happens when metadata is supplied is documented.
+	Metadata map[string]interface{} `json:"metadata"`
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
There is no existing way to get only the accounts that are staking to a particular validator on Polkadot. This PR allows us to pass those addresses directly to the rosetta impl.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
PR adds a metadata field to the request that is optional but will contain an array of address strings

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
